### PR TITLE
Revert Beacon change

### DIFF
--- a/src/client/java/barker/justin/trglass/Main.java
+++ b/src/client/java/barker/justin/trglass/Main.java
@@ -19,6 +19,5 @@ public class Main implements ClientModInitializer {
         });
         BlockRenderLayerMap.INSTANCE.putBlock(Blocks.GLASS, RenderLayer.getTranslucent());
         BlockRenderLayerMap.INSTANCE.putBlock(Blocks.GLASS_PANE, RenderLayer.getTranslucent());
-        BlockRenderLayerMap.INSTANCE.putBlock(Blocks.BEACON, RenderLayer.getTranslucent());
     }
 }


### PR DESCRIPTION
In the process of updating to 1.21, code to include Beacons as translucent alongside glass and glass panes was unintentionally pushed. This change was originally made testing #3, but currently due to limitations in Sodium pre-0.6 I am choosing not to add this change for now.